### PR TITLE
Don't hard-code the admin url

### DIFF
--- a/pinax_theme_bootstrap/templates/_account_bar.html
+++ b/pinax_theme_bootstrap/templates/_account_bar.html
@@ -5,7 +5,7 @@
             <ul class="menu-dropdown">
                 <li><a href="{% url acct_email %}">Account</a></li>
                 {% if user.is_staff %}
-                    <li><a href="/admin/">Admin</a></li>
+                    <li><a href="{% url admin:index %}">Admin</a></li>
                 {% endif %}
                 <li class="divider"></li>
                 <li><a href="{% url acct_logout %}">Log Out</a></li>


### PR DESCRIPTION
This little patch replaces the hard-coded admin link with a {% url... %} template tag
