### PR TITLE
Add the ability to use the fluid layout instead of the default fixed layout

### DIFF
--- a/README
+++ b/README
@@ -42,6 +42,17 @@ and do something like:
     </form>
 
 
+Bootstrap layout
+----------------
+
+http://twitter.github.com/bootstrap/#layouts
+By default, the fixed layout is used. If you want to use the fluid layout add:
+    "pinax_theme_bootstrap.context_processors.bootstrap_layout"
+to TEMPLATE_CONTEXT_PROCESSORS and
+    BOOTSTRAP_LAYOUT = 'fluid'
+in the settings.py file.
+
+
 Todo / Issues
 -------------
 

--- a/pinax_theme_bootstrap/context_processors.py
+++ b/pinax_theme_bootstrap/context_processors.py
@@ -1,0 +1,26 @@
+from django.conf import settings
+
+LAYOUT_SETTING = 'BOOTSTRAP_LAYOUT'
+LAYOUT_CONTAINER_CLASSES = {
+    'fixed': 'container',
+    'fluid': 'container-fluid'
+}
+DEFAULT_LAYOUT = 'fixed'
+
+def bootstrap_layout(request):
+    """
+    Set the bootstrap_container_class value in the template context based
+    on the BOOTSTRAP_LAYOUT setting value:
+        - fixed: container
+        - fluid: container-fluid
+    """
+    layout = getattr(settings, LAYOUT_SETTING, DEFAULT_LAYOUT)
+    try:
+        bootstrap_container_class = LAYOUT_CONTAINER_CLASSES[layout]
+    except KeyError:
+        # An invalid value was provided
+        raise ValueError(
+            "'%s' is not a valid value for %s. Choices are: '%s'"
+            % (layout, LAYOUT_SETTING, LAYOUT_CONTAINER_CLASSES.keys())
+        )
+    return {'bootstrap_container_class': bootstrap_container_class}

--- a/pinax_theme_bootstrap/templates/banner_base.html
+++ b/pinax_theme_bootstrap/templates/banner_base.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 
 {% block body_base %}
-    <div class="container">
+    <div class="{{ bootstrap_container_class|default:'container' }}">
         {% include "_messages.html" %}
         <div class="hero-unit">
         {% block banner %}

--- a/pinax_theme_bootstrap/templates/subnav_base.html
+++ b/pinax_theme_bootstrap/templates/subnav_base.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 
 {% block body_base %}
-    <div class="container">
+    <div class="{{ bootstrap_container_class|default:'container' }}">
         {% include "_messages.html" %}
         <div class="row">
             <div class="span4 columns">

--- a/pinax_theme_bootstrap/templates/theme_base.html
+++ b/pinax_theme_bootstrap/templates/theme_base.html
@@ -30,7 +30,7 @@
         {% block topbar_base %}
             <div class="topbar">
                 <div class="fill">
-                    <div class="container">
+                    <div class="{{ bootstrap_container_class|default:'container' }}">
                         {% block topbar %}
                             <h3><a href="{% url home %}">{{ SITE_NAME }}</a></h3>
                             {% block nav %}{% endblock %}
@@ -42,7 +42,7 @@
         {% endblock %}
         
         {% block body_base %}
-            <div class="container">
+            <div class="{{ bootstrap_container_class|default:'container' }}">
                 {% include "_messages.html" %}
                 {% block body %}
                 {% endblock %}
@@ -52,7 +52,7 @@
         {% block footer_base %}
             <div id="footer">
                 <div class="inner">
-                    <div class="container">
+                    <div class="{{ bootstrap_container_class|default:'container' }}">
                         {% block footer %}{% endblock %}
                     </div>
                 </div>


### PR DESCRIPTION
This is done by replacing the 'container' class by 'container-fluid'. 

I've added a context_processor that will load the value of the `BOOTSTRAP_LAYOUT` setting and set the `bootstrap_container_class` in the template context to `container` or `container-fluid` based on the layout chosen (fixed is the default one). 

In the templates, the `container` value for the class attribute is replaced by `{{ bootstrap_container_class|default:'container' }}` (still works when the context processor is not added).
