### PR TITLE
fix for new class name (navbar-fixed-top)

### DIFF
--- a/pinax_theme_bootstrap/templates/theme_base.html
+++ b/pinax_theme_bootstrap/templates/theme_base.html
@@ -37,7 +37,7 @@
     <body class="{% block body_class %}{% endblock %}" id="{% block body_id %}{% endblock %}">
         
         {% block topbar_base %}
-            <div class="navbar navbar-fixed">
+            <div class="navbar navbar-fixed-top">
                 <div class="navbar-inner">
                     <div class="container">
                         {% block topbar %}


### PR DESCRIPTION
The latest bootstrap changed the name of the navbar-fixed class to navbar-fixed-top.
