### PR TITLE
Removing hardcoded paths

### DIFF
--- a/pinax_theme_bootstrap/static/bootstrap/less/sprites.less
+++ b/pinax_theme_bootstrap/static/bootstrap/less/sprites.less
@@ -21,14 +21,14 @@
   height: 14px;
   line-height: 14px;
   vertical-align: text-top;
-  background-image: url("../img/glyphicons-halflings.png");
+  background-image: url("@{iconSpritePath}");
   background-position: 14px 14px;
   background-repeat: no-repeat;
 
   .ie7-restore-right-whitespace();
 }
 .icon-white {
-  background-image: url("../img/glyphicons-halflings-white.png");
+  background-image: url("@{iconWhiteSpritePath}");
 }
 
 .icon-glass              { background-position: 0      0; }


### PR DESCRIPTION
So the recent change to add a hard coded path isn't actually a bug in less, but rather a bug in bootstrap. See the original change by DominikTo at https://github.com/twitter/bootstrap/commit/7609fd4dc62dfdc83c08fe32cbcd2b8e5cac5500#less/sprites.less

Basically replicated his change and tested against the less-1.2.2.min.js included in bootstrap and it's happy with it.
