### PR TITLE
delete template missing future url and quotes

### DIFF
--- a/pinax_theme_bootstrap/templates/account/delete.html
+++ b/pinax_theme_bootstrap/templates/account/delete.html
@@ -2,6 +2,7 @@
 
 {% load i18n %}
 {% load bootstrap_tags %}
+{% load url from future %}
 
 {% block head_title %}Delete Account{% endblock %}
 
@@ -10,7 +11,7 @@
     
     <p>If you go ahead and delete your account, your information will be <b>expunged within {{ ACCOUNT_DELETION_EXPUNGE_HOURS }} hours</b>.</p>
     
-    <form method="post" action="{% url account_delete %}" autocapitalize="off">
+    <form method="post" action="{% url "account_delete" %}" autocapitalize="off">
         {% csrf_token %}
         <button type="submit" class="btn btn-danger">Delete My Account</button>
     </form>


### PR DESCRIPTION
Updated delete.html to use url from future and put quotes around url in tag to correct 

```
'url' requires a non-empty first argument. The syntax changed in Django 1.5, see the docs.
```
