### PR TITLE
Fixed navbar dropdown menu response bug

### DIFF
--- a/pinax_theme_bootstrap/templates/theme_bootstrap/base.html
+++ b/pinax_theme_bootstrap/templates/theme_bootstrap/base.html
@@ -41,7 +41,7 @@
                                     <span class="icon-bar"></span>
                                 </a>
                                 {% block site_brand %}<a class="brand" href="{% url "home" %}">{{ SITE_NAME }}</a>{% endblock %}
-                                <div class="nav-collapse">
+                                <div class="nav-collapse collapse navbar-responsive-collapse">
                                     {% block nav %}
                                         {% comment %}
                                             <ul class="nav">


### PR DESCRIPTION
Added classes 'collapse' and 'navbar-responsive-collapse' to the nav-collapse div on line 44.  Dropdown menus were not responding properly in the collapsed response state.  Adding these two classes fixed this for me.

You should be able to reproduce the bug I was experiencing by shrinking the width to cause the navbar collapse response.  Do it while you're signed in so there is an account dropdown menu for you.  At this point, for me, the dropdown menu for settings and logout wouldn't drop.  The collapse and navbar-responsive-collapse class declarations on the parent div tag fixed this for me.
