### PR TITLE
FIX: pagination template with THOUSAND_SEPARATOR

### DIFF
--- a/pinax_theme_bootstrap/templates/pagination/builtin_pagination.html
+++ b/pinax_theme_bootstrap/templates/pagination/builtin_pagination.html
@@ -6,16 +6,16 @@
     <ul class="pagination">
         {% if page_obj.has_previous %}
             <li class="prev">
-                <a href="?page={{ page_obj.previous_page_number }}{{ getvars }}{{ hashtag }}">← {% trans "Previous" %}</a>
+                <a href="?page={{ page_obj.previous_page_number|stringformat:"d" }}{{ getvars }}{{ hashtag }}">← {% trans "Previous" %}</a>
             </li>
         {% else %}
             <li class="prev disabled"><a>← {% trans "Previous" %}</a></li>
         {% endif %}
         {% for page in paginator.page_range %}
-            <li class="{% ifequal page page_obj.number %}active{% endifequal %}"><a href="?page={{ page }}{{ getvars }}{{ hashtag }}">{{ page }}</a></li>
+            <li class="{% ifequal page page_obj.number %}active{% endifequal %}"><a href="?page={{ page|stringformat:"d" }}{{ getvars }}{{ hashtag }}">{{ page|stringformat:"d" }}</a></li>
         {% endfor %}
         {% if page_obj.has_next %}
-            <li class="next"><a href="?page={{ page_obj.next_page_number }}{{ getvars }}{{ hashtag }}">{% trans "Next" %} →</a></li>
+            <li class="next"><a href="?page={{ page_obj.next_page_number|stringformat:"d" }}{{ getvars }}{{ hashtag }}">{% trans "Next" %} →</a></li>
         {% else %}
             <li class="next disabled"><a>{% trans "Next" %} →</a></li>
         {% endif %}

--- a/pinax_theme_bootstrap/templates/pagination/django_pagination_pagination.html
+++ b/pinax_theme_bootstrap/templates/pagination/django_pagination_pagination.html
@@ -5,20 +5,20 @@
     <ul class="pagination">
         {% if page_obj.has_previous %}
             <li class="prev">
-                <a href="?page={{ page_obj.previous_page_number }}{{ getvars }}{{ hashtag }}">← {% trans "Previous" %}</a>
+                <a href="?page={{ page_obj.previous_page_number|stringformat:"d" }}{{ getvars }}{{ hashtag }}">← {% trans "Previous" %}</a>
             </li>
         {% else %}
             <li class="prev disabled"><a>← {% trans "Previous" %}</a></li>
         {% endif %}
         {% for page in pages %}
             {% if page %}
-                <li class="{% ifequal page page_obj.number %}active{% endifequal %}"><a href="?page={{ page }}{{ getvars }}{{ hashtag }}">{{ page }}</a></li>
+                <li class="{% ifequal page page_obj.number %}active{% endifequal %}"><a href="?page={{ page|stringformat:"d" }}{{ getvars }}{{ hashtag }}">{{ page|stringformat:"d" }}</a></li>
             {% else %}
                 <li class="disabled"><a href="#">…</a></li>
             {% endif %}
         {% endfor %}
         {% if page_obj.has_next %}
-            <li class="next"><a href="?page={{ page_obj.next_page_number }}{{ getvars }}{{ hashtag }}">{% trans "Next" %} →</a></li>
+            <li class="next"><a href="?page={{ page_obj.next_page_number|stringformat:"d" }}{{ getvars }}{{ hashtag }}">{% trans "Next" %} →</a></li>
         {% else %}
             <li class="next disabled"><a>{% trans "Next" %} →</a></li>
         {% endif %}


### PR DESCRIPTION
Fixes incorrect urls in pagination templates when THOUSAND_SEPARATOR is
used, ie: ?page=1.000

Also do not use THOUSAND_SEPARATOR when displaying page numbers.
