### PR TITLE
Importing of settings is required for AppConf

### DIFF
--- a/pinax_theme_bootstrap/conf.py
+++ b/pinax_theme_bootstrap/conf.py
@@ -1,3 +1,5 @@
+from django.conf import settings  # noqa
+
 from appconf import AppConf
 
 


### PR DESCRIPTION
This currently breaks the context processor. See https://pypi.python.org/pypi/django-appconf
