### PR TITLE
added readme line to set context processors correctly

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,10 @@ Include "pinax-theme-bootstrap" in your requirements file and include
 "pinax_theme_bootstrap" and "bootstrapform" (which is installed alongside
 this theme) in your INSTALLED APPS.
 
+Add 'django.core.context_processors.request' and
+"pinax_theme_bootstrap.context_processors.theme" to your TEMPLATE_CONTEXT_PROCESSORS
+to ensure the user selector and site name work correctly.
+
 Make sure both template loaders and staticfiles finders includes
 app directories.
 


### PR DESCRIPTION
If you don't have 'pinax_theme_bootstrap.context_processors.theme' in your TEMPLATE_CONTEXT_PROCESSORS setting the site name won't populate templates correctly; similarly, templates now get passed a user context by Django to determine user info, but pinax_theme_bootstrap expects a request context, which the template won't get unless you've set 'django.core.context_processors.request' as a context processor. While the second one should probably just be fixed, for now I've simply updated the readme to reflect the settings.
