### PR TITLE
Pull in body, section and footer styles from pinax starter projects

### DIFF
--- a/pinax_theme_bootstrap/static/pinax/css/theme.css
+++ b/pinax_theme_bootstrap/static/pinax/css/theme.css
@@ -1,19 +1,13 @@
 body {
-  padding-top: 80px;
+  padding-top: 50px;
   position: relative;
 }
 section {
-  padding-top: 60px;
+  padding: 20px 0px;
 }
 .modal form {
   margin-bottom: 0px;
 }
-#footer {
-  margin-top: 80px;
-}
-#footer p {
-  margin-bottom: 0;
-}
-#footer p.right {
-  float: right;
+footer {
+    padding-bottom: 20px;
 }


### PR DESCRIPTION
The following starter projects are based off of pinax-theme-bootstrap and all share customizations of theme.css:

* [pinax-project-account](https://github.com/pinax/pinax-project-account)
* [pinax-project-socialauth](https://github.com/pinax/pinax-project-socialauth)
* [pinax-project-zero](https://github.com/pinax/pinax-project-zero)

This PR pulls those overrides back to theme.css, and once a new release of pinax-theme-bootstrap has been issued, the overrides can be removed from each starter project.