### PR TITLE
Fix .alert- prefix on message tags

### DIFF
--- a/pinax_theme_bootstrap/templates/_messages.html
+++ b/pinax_theme_bootstrap/templates/_messages.html
@@ -1,5 +1,6 @@
+{% load pinax_theme_bootstrap_tags %}
 {% for message in messages %}
-    <div class="alert fade in {% if message.tags %} alert-{{ message.tags }}{% endif %}">
+    <div class="alert fade in {% get_message_tags message %}">
         <button type="button" class="close" data-dismiss="alert">&times;</button>
         {{ message }}
     </div>

--- a/pinax_theme_bootstrap/templatetags/pinax_theme_bootstrap_tags.py
+++ b/pinax_theme_bootstrap/templatetags/pinax_theme_bootstrap_tags.py
@@ -1,0 +1,3 @@
+from django import template
+
+register = template.Library()

--- a/pinax_theme_bootstrap/templatetags/pinax_theme_bootstrap_tags.py
+++ b/pinax_theme_bootstrap/templatetags/pinax_theme_bootstrap_tags.py
@@ -1,4 +1,8 @@
 from django import template
+from django.contrib.messages.utils import get_level_tags
+
+
+LEVEL_TAGS = get_level_tags()
 
 register = template.Library()
 
@@ -8,6 +12,11 @@ def get_message_tags(message):
     """
     Returns tags for a message
     """
-    if message.tags:
-        return u"alert-{tags}".format(tags=message.tags)
-    return u""
+    level_name = LEVEL_TAGS[message.level]
+    level_tag = u"alert-{name}".format(name=level_name)
+
+    tags = [level_tag]
+    if message.extra_tags:
+        tags.append(message.extra_tags)
+
+    return u" ".join(tags)

--- a/pinax_theme_bootstrap/templatetags/pinax_theme_bootstrap_tags.py
+++ b/pinax_theme_bootstrap/templatetags/pinax_theme_bootstrap_tags.py
@@ -1,5 +1,6 @@
 from django import template
 from django.contrib.messages.utils import get_level_tags
+from django.utils.encoding import force_text
 
 
 LEVEL_TAGS = get_level_tags()
@@ -15,14 +16,15 @@ def get_message_tags(message):
 
     Messages in Django >= 1.7 have a message.level_tag attr
     """
-    level_tag = LEVEL_TAGS[message.level]
+    level_tag = force_text(LEVEL_TAGS.get(message.level, ''), strings_only=True)
     if level_tag == u"error":
         level_tag = u"danger"
 
     alert_level_tag = u"alert-{tag}".format(tag=level_tag)
 
     tags = [alert_level_tag]
-    if message.extra_tags:
-        tags.append(message.extra_tags)
+    extra_tags = force_text(message.extra_tags, strings_only=True)
+    if extra_tags:
+        tags.append(extra_tags)
 
     return u" ".join(tags)

--- a/pinax_theme_bootstrap/templatetags/pinax_theme_bootstrap_tags.py
+++ b/pinax_theme_bootstrap/templatetags/pinax_theme_bootstrap_tags.py
@@ -18,6 +18,8 @@ def get_message_tags(message):
     """
     level_tag = force_text(LEVEL_TAGS.get(message.level, ''), strings_only=True)
     if level_tag == u"error":
+        # Alias the error tag as danger, since .alert-error no longer exists
+        # in Bootstrap 3
         level_tag = u"danger"
 
     if level_tag:

--- a/pinax_theme_bootstrap/templatetags/pinax_theme_bootstrap_tags.py
+++ b/pinax_theme_bootstrap/templatetags/pinax_theme_bootstrap_tags.py
@@ -13,6 +13,9 @@ def get_message_tags(message):
     Returns tags for a message
     """
     level_name = LEVEL_TAGS[message.level]
+    if level_name == u"error":
+        level_name = u"danger"
+
     level_tag = u"alert-{name}".format(name=level_name)
 
     tags = [level_tag]

--- a/pinax_theme_bootstrap/templatetags/pinax_theme_bootstrap_tags.py
+++ b/pinax_theme_bootstrap/templatetags/pinax_theme_bootstrap_tags.py
@@ -1,3 +1,13 @@
 from django import template
 
 register = template.Library()
+
+
+@register.simple_tag()
+def get_message_tags(message):
+    """
+    Returns tags for a message
+    """
+    if message.tags:
+        return u"alert-{tags}".format(tags=message.tags)
+    return u""

--- a/pinax_theme_bootstrap/templatetags/pinax_theme_bootstrap_tags.py
+++ b/pinax_theme_bootstrap/templatetags/pinax_theme_bootstrap_tags.py
@@ -10,15 +10,18 @@ register = template.Library()
 @register.simple_tag()
 def get_message_tags(message):
     """
-    Returns tags for a message
+    Returns the message's level_tag prefixed with Bootstrap's "alert-" prefix
+    along with any tags included in message.extra_tags
+
+    Messages in Django >= 1.7 have a message.level_tag attr
     """
-    level_name = LEVEL_TAGS[message.level]
-    if level_name == u"error":
-        level_name = u"danger"
+    level_tag = LEVEL_TAGS[message.level]
+    if level_tag == u"error":
+        level_tag = u"danger"
 
-    level_tag = u"alert-{name}".format(name=level_name)
+    alert_level_tag = u"alert-{tag}".format(tag=level_tag)
 
-    tags = [level_tag]
+    tags = [alert_level_tag]
     if message.extra_tags:
         tags.append(message.extra_tags)
 

--- a/pinax_theme_bootstrap/templatetags/pinax_theme_bootstrap_tags.py
+++ b/pinax_theme_bootstrap/templatetags/pinax_theme_bootstrap_tags.py
@@ -20,11 +20,17 @@ def get_message_tags(message):
     if level_tag == u"error":
         level_tag = u"danger"
 
-    alert_level_tag = u"alert-{tag}".format(tag=level_tag)
+    if level_tag:
+        alert_level_tag = u"alert-{tag}".format(tag=level_tag)
+    else:
+        alert_level_tag = None
 
-    tags = [alert_level_tag]
     extra_tags = force_text(message.extra_tags, strings_only=True)
-    if extra_tags:
-        tags.append(extra_tags)
 
-    return u" ".join(tags)
+    if extra_tags and alert_level_tag:
+        return u' '.join([extra_tags, alert_level_tag])
+    elif extra_tags:
+        return extra_tags
+    elif alert_level_tag:
+        return alert_level_tag
+    return u''


### PR DESCRIPTION
Previously, a prefix of "alert-" was added to message.tags to correspond to alert classes defined by Bootstrap.

Any additional tags added to a message (via message.extra_tags) are inserted **before** the tag corresponding to the message's level, so any time a message had extra_tags defined, the alert prefix would not be applied to the message level tag.

Django 1.7 [added the ability to reference the level_tag](https://docs.djangoproject.com/en/1.7/ref/contrib/messages/#django.contrib.messages.storage.base.Message) directly, but to maintain compatibility with earlier versions of Django, the ***get_message_tags*** template tag is used instead.

Also resolves #66 by changing the level_tag  returned by messages.ERROR to "danger" within get_message_tags, as .alert-error no longer exists under Bootstrap 2.

This could also be done by aliasing .alert-error as .alert-danger within the LESS for a project, but that would require changes to each of the Pinax starter projects as well (see #86), as there isn't currently a custom LESS file in this project.