### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ AUTHOR_EMAIL = "jtauber@jtauber.com"
 URL = "http://github.com/pinax/pinax-theme-bootstrap"
 VERSION = __import__(PACKAGE).__version__
 INSTALL_REQUIRES = [
-    "django-appconf==0.6",
+    "django-appconf>=0.6",
     "django-bootstrap-form>=3.0.0",
 ]
 


### PR DESCRIPTION
Just upgraded django-appconf to 1.0.1 and I'm now seeing this error:

```
ContextualVersionConflict: (django-appconf 1.0.1 (/Users/foo/.virtualenvs/bar/lib/python2.7/site-packages),
Requirement.parse('django-appconf==0.6'), set(['pinax-theme-bootstrap']))
```
This PR allows newer versions of django-appconf.