### PR TITLE
missing i18n load

### DIFF
--- a/pinax_theme_bootstrap/templates/account/settings.html
+++ b/pinax_theme_bootstrap/templates/account/settings.html
@@ -1,5 +1,5 @@
 {% extends "account/base.html" %}
-
+{% load i18n %}
 {% load url from future %}
 {% load bootstrap %}
 


### PR DESCRIPTION
mandatory to use the `trans` templatetag