### PR TITLE
django-user-accounts templates reference removed template block

### DIFF
--- a/pinax_theme_bootstrap/templates/account/login.html
+++ b/pinax_theme_bootstrap/templates/account/login.html
@@ -32,7 +32,8 @@
     </div>
 {% endblock %}
 
-{% block extra_script %}
+{% block scripts %}
+    {{ block.super }}
     <script type="text/javascript">
         $(document).ready(function() {
             $('#id_username').focus();

--- a/pinax_theme_bootstrap/templates/account/signup.html
+++ b/pinax_theme_bootstrap/templates/account/signup.html
@@ -29,7 +29,8 @@
     </div>
 {% endblock %}
 
-{% block extra_script %}
+{% block scripts %}
+    {{ block.super }}
     <script type="text/javascript">
         $(document).ready(function() {
             $('#id_username').focus();


### PR DESCRIPTION
`scripts` replaces the `extra_scripts` block.