### PR TITLE
Adding detail template.

### DIFF
--- a/pinax_theme_bootstrap/templates/pinax/announcements/announcement_detail.html
+++ b/pinax_theme_bootstrap/templates/pinax/announcements/announcement_detail.html
@@ -1,0 +1,8 @@
+{% extends "site_base.html" %}
+
+{% block head_title %}{{ announcement.title }}{% endblock %}
+
+{% block body %}
+    <h1>{{ announcement }}</h1>
+
+{% endblock %}


### PR DESCRIPTION
This template is required for the new detail view.

Since we added templates for the "announcements" Pinax application, perhaps PTB should be updated to v7.4.0 or v7.3.1 and then published.