### PR TITLE
Pass request to Site.get_current

### DIFF
--- a/pinax_theme_bootstrap/context_processors.py
+++ b/pinax_theme_bootstrap/context_processors.py
@@ -10,7 +10,7 @@ def theme(request):
     }
 
     if Site._meta.installed:
-        site = Site.objects.get_current()
+        site = Site.objects.get_current(request)
         ctx.update({
             "SITE_NAME": site.name,
             "SITE_DOMAIN": site.domain


### PR DESCRIPTION
This adds support for instances of django without SITE_ID.

Fixes:

```
Traceback (most recent call last):
  File "/home/jpic/james/james_env/lib/python3.5/site-packages/django/core/handlers/exception.py", line 39, in inner
    response = get_response(request)
  File "/home/jpic/james/james_env/lib/python3.5/site-packages/django/core/handlers/base.py", line 248, in _legacy_get_response
    response = self._get_response(request)
  File "/home/jpic/james/james_env/lib/python3.5/site-packages/django/core/handlers/base.py", line 216, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/home/jpic/james/james_env/lib/python3.5/site-packages/django/core/handlers/base.py", line 214, in _get_response
    response = response.render()
  File "/home/jpic/james/james_env/lib/python3.5/site-packages/django/template/response.py", line 109, in render
    self.content = self.rendered_content
  File "/home/jpic/james/james_env/lib/python3.5/site-packages/django/template/response.py", line 86, in rendered_content
    content = template.render(context, self._request)
  File "/home/jpic/james/james_env/lib/python3.5/site-packages/django/template/backends/django.py", line 66, in render
    return self.template.render(context)
  File "/home/jpic/james/james_env/lib/python3.5/site-packages/django/template/base.py", line 206, in render
    with context.bind_template(self):
  File "/usr/lib64/python3.5/contextlib.py", line 59, in __enter__
    return next(self.gen)
  File "/home/jpic/james/james_env/lib/python3.5/site-packages/debug_toolbar/panels/templates/panel.py", line 79, in _request_context_bind_template
    context = processor(self.request)
  File "/home/jpic/james/james_env/src/pinax-theme-bootstrap/pinax_theme_bootstrap/context_processors.py", line 13, in theme
    site = Site.objects.get_current()
  File "/home/jpic/james/james_env/lib/python3.5/site-packages/django/contrib/sites/models.py", line 70, in get_current
    "You're using the Django \"sites framework\" without having "
django.core.exceptions.ImproperlyConfigured: You're using the Django "sites framework" without having set the SITE_ID setting. Create a site in your database and set the SITE_ID setting or pass a request to Site.objects.get_current() to fix this error.
```
