### PR TITLE
Update pinax/js/theme.js reference quotes

### DIFF
--- a/pinax_theme_bootstrap/templates/theme_bootstrap/base.html
+++ b/pinax_theme_bootstrap/templates/theme_bootstrap/base.html
@@ -75,7 +75,7 @@
         {% block scripts %}{% endblock %}
 
         {% block theme_script %}
-            <script src="{% static "pinax/js/theme.js" %}"></script>
+            <script src="{% static 'pinax/js/theme.js' %}"></script>
         {% endblock %}
 
         {% block extra_body_base %}


### PR DESCRIPTION
Script tag is opening and closing with double-quotes, the double-quotes within the static templatetag was causing an IDE issue with improperly recognizing which text was quoted, and what was not.