### PR TITLE
Fix url reference with correct namespace

### DIFF
--- a/pinax_theme_bootstrap/templates/pinax/invitations/_invite_form.html
+++ b/pinax_theme_bootstrap/templates/pinax/invitations/_invite_form.html
@@ -3,7 +3,7 @@
 
 <div class="pinax_invitations:invites_form">
     {% if user.invitationstat.can_send %}
-        <form action="{% url "pinax-invitations-invite" %}"
+        <form action="{% url "pinax_invitations:invite" %}"
               class="form ajax"
               data-replace-closest=".pinax-invitations-invites-form"
               method="POST"


### PR DESCRIPTION
The old ("pinax-invitations-invite") URL name has not been valid for a long time. This update uses namespaces in the template.